### PR TITLE
chore: add interfaces to mock client in destinations

### DIFF
--- a/apiclient.go
+++ b/apiclient.go
@@ -16,11 +16,24 @@ const (
 	apiURL = "https://api.us-east-2.propeldata.com/graphql"
 )
 
+type PropelApiClient interface {
+	CreateDataSource(ctx context.Context, opts CreateDataSourceOpts) (*models.DataSource, error)
+	FetchDataSource(ctx context.Context, uniqueName string) (*models.DataSource, error)
+	FetchDataPool(ctx context.Context, uniqueName string) (*models.DataPool, error)
+	FetchRecordsByUniqueId(ctx context.Context, dataPoolName string, uniqueIds []string, columnNames []string) (*models.RecordsByUniqueIdResponse, error)
+	CreateDeletionJob(ctx context.Context, dataPoolId string, filters []models.FilterInput) (*models.Job, error)
+	FetchDeletionJob(ctx context.Context, id string) (*models.Job, error)
+	CreateAddColumnJob(ctx context.Context, dataPoolId string, columnName string, columnType string) (*models.Job, error)
+	FetchAddColumnJob(ctx context.Context, id string) (*models.Job, error)
+}
+
 type ApiClient struct {
 	client *graphql.Client
 }
 
-func NewApiClient(accessToken string) *ApiClient {
+var _ PropelApiClient = (*ApiClient)(nil)
+
+func NewApiClient(accessToken string) PropelApiClient {
 	httpClient := newHttpClient(Options{
 		Timeout: 3 * time.Second,
 		Retries: 3,

--- a/oauthclient.go
+++ b/oauthclient.go
@@ -14,6 +14,10 @@ const (
 	oauthURL = "https://auth.us-east-2.propeldata.com/oauth2/token"
 )
 
+type PropelOAuthClient interface {
+	OAuthToken(ctx context.Context, applicationID, applicationSecret string) (*OAuthToken, error)
+}
+
 type OauthClient struct {
 	client *http.Client
 }
@@ -23,7 +27,9 @@ type OAuthToken struct {
 	ExpiresIn   int    `json:"expires_in"`
 }
 
-func NewOauthClient() *OauthClient {
+var _ PropelOAuthClient = (*OauthClient)(nil)
+
+func NewOauthClient() PropelOAuthClient {
 	client := newHttpClient(Options{
 		Timeout: 2 * time.Second,
 		Retries: 3,

--- a/webhookclient.go
+++ b/webhookclient.go
@@ -11,11 +11,18 @@ import (
 	"github.com/pkg/errors"
 )
 
+type PropelWebhookClient interface {
+	PostEvents(ctx context.Context, input *PostEventsInput) ([]error, error)
+	DeleteEvents(ctx context.Context, input *PostEventsInput) ([]error, error)
+}
+
 type WebhookClient struct {
 	client *http.Client
 }
 
-func NewWebhookClient() *WebhookClient {
+var _ PropelWebhookClient = (*WebhookClient)(nil)
+
+func NewWebhookClient() PropelWebhookClient {
 	client := newHttpClient(Options{
 		Timeout: 10 * time.Second,
 		Retries: 3,


### PR DESCRIPTION
I want to easily mock our API requests for thorough unit tests in our destinations. Interfaces allow me to implement these methods and mock different results and errors without actually calling our API.