### PR TITLE
fix: consider null values

### DIFF
--- a/models/records.go
+++ b/models/records.go
@@ -12,8 +12,8 @@ type RecordsByUniqueIdInput struct {
 }
 
 type RecordsByUniqueIdResponse struct {
-	Columns []string   `json:"columns"`
-	Values  [][]string `json:"values"`
+	Columns []string    `json:"columns"`
+	Values  [][]*string `json:"values"`
 }
 
 type RecordsByUniqueId struct {


### PR DESCRIPTION
When fetching records by id, if a record is null it results as an empty string when parsed. The pointer allows it to correctly be parsed as `nil`.